### PR TITLE
Update flask_superadmin/model/backends/mongoengine/orm.py

### DIFF
--- a/flask_superadmin/model/backends/mongoengine/orm.py
+++ b/flask_superadmin/model/backends/mongoengine/orm.py
@@ -88,7 +88,9 @@ class ModelConverter(object):
         if field.regex:
             kwargs['validators'].append(validators.Regexp(regex=field.regex))
         self._string_common(model, field, kwargs)
-        return f.TextField(**kwargs)
+        if field.max_length:
+            return f.TextField(**kwargs)
+        return f.TextAreaField(**kwargs)
 
     @converts('URLField')
     def conv_URL(self, model, field, kwargs):


### PR DESCRIPTION
StringFields are converted to TextAreaFields if max_length is not set for them. (Same as Flask-Mongoengine.)
