### PR TITLE
Support passing methods to list_display

### DIFF
--- a/flask_superadmin/model/backends/mongoengine/view.py
+++ b/flask_superadmin/model/backends/mongoengine/view.py
@@ -27,10 +27,13 @@ class ModelAdmin(BaseModelAdmin):
         return False
 
     def is_sortable(self, column):
-        return isinstance(self.get_column(self.model, column), SORTABLE_FIELDS)
+        field = getattr(self.model, column, None)
+        return isinstance(field, SORTABLE_FIELDS)
 
     def get_column(self, instance, name):
         value = getattr(instance, name, None)
+        if callable(value):
+            value = value()
         field = instance._fields.get(name, None)
         if field and field.choices:
             choices = dict(field.choices)


### PR DESCRIPTION
Imagine having a simple MongoEngine document and a model admin:

```
class User(Document):
    email = StringField(required=True)
    first_name = StringField(max_length=50)
    last_name = StringField(max_length=50)

    def get_full_name(self):
        return '%s %s' % (self.first_name, self.last_name)

class TestAdmin(model.ModelAdmin):
    list_display = ['get_full_name']
```

It would show `<bound method Test.get_full_name of <Test: Test object>>` in the list. This pull request fixes it by checking if an attribute is callable.
