### PR TITLE
Pass instance to the edit template's context

### DIFF
--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -247,7 +247,7 @@ class BaseModelAdmin(BaseView):
             form = Form(obj=instance)
 
         return self.render(self.edit_template, model=self.model, form=form,
-                           pk=self.get_pk(instance))
+                           pk=self.get_pk(instance), instance=instance)
 
     @expose('/<pk>/delete', methods=('GET', 'POST'))
     def delete(self, pk=None, *pks):


### PR DESCRIPTION
Having an instance in the context by default helps greatly, if you customize the `edit_template`.
