### PR TITLE
Support passing methods to list_display

### DIFF
--- a/flask_superadmin/model/backends/django/view.py
+++ b/flask_superadmin/model/backends/django/view.py
@@ -13,7 +13,7 @@ class ModelAdmin(BaseModelAdmin):
         return False
 
     def get_column(self, instance, name):
-        return getattr(instance, name, None)
+        return self.get_column_value(getattr(instance, name, None))
 
     def get_form(self, adding=False):
         return model_form(self.model,

--- a/flask_superadmin/model/backends/mongoengine/view.py
+++ b/flask_superadmin/model/backends/mongoengine/view.py
@@ -32,13 +32,11 @@ class ModelAdmin(BaseModelAdmin):
 
     def get_column(self, instance, name):
         value = getattr(instance, name, None)
-        if callable(value):
-            value = value()
         field = instance._fields.get(name, None)
         if field and field.choices:
             choices = dict(field.choices)
             if value in choices: return choices[value]
-        return value
+        return self.get_column_value(value)
 
     def get_form(self, adding=False):
         return model_form(self.model,

--- a/flask_superadmin/model/backends/sqlalchemy/view.py
+++ b/flask_superadmin/model/backends/sqlalchemy/view.py
@@ -43,7 +43,7 @@ class ModelAdmin(BaseModelAdmin):
         return False
 
     def get_column(self, instance, name):
-        return getattr(instance, name, None)
+        return self.get_column_value(getattr(instance, name, None))
 
     def get_form(self, adding=False):
         return model_form(self.model,

--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -92,6 +92,11 @@ class BaseModelAdmin(BaseView):
     def allow_pk(self):
         return not self.model._meta.auto_increment
 
+    def get_column_value(self, value):
+        if callable(value):
+            return value()
+        return value
+
     def get_form(self, adding=False):
         return model_form(self.model, only=self.fields, exclude=self.exclude,
                           converter=CustomModelConverter(self))


### PR DESCRIPTION
Imagine having a simple MongoEngine document and a model admin:

```
class User(Document):
    email = StringField(required=True)
    first_name = StringField(max_length=50)
    last_name = StringField(max_length=50)

    def get_full_name(self):
        return '%s %s' % (self.first_name, self.last_name)

class TestAdmin(model.ModelAdmin):
    list_display = ['get_full_name']
```

It would show `<bound method Test.get_full_name of <Test: Test object>>` in the list. This pull request fixes it by checking if an attribute is callable. This is accomplished by using `BaseModelAdmin.get_column_value` from within specific model admin's `get_column`.
