### PR TITLE
Allow custom querysets.

### DIFF
--- a/flask_superadmin/model/backends/django/view.py
+++ b/flask_superadmin/model/backends/django/view.py
@@ -23,8 +23,11 @@ class ModelAdmin(BaseModelAdmin):
                           field_args=self.field_args,
                           converter=AdminModelConverter())
 
+    def get_queryset(self):
+        return self.model.objects
+
     def get_objects(self, *pks):
-        return self.model.objects.filter(pk__in=pks)
+        return self.get_queryset().filter(pk__in=pks)
 
     def get_object(self, pk):
         return self.model.objects.get(pk=pk)
@@ -42,26 +45,21 @@ class ModelAdmin(BaseModelAdmin):
         return True
 
     def get_list(self, page=0, sort=None, sort_desc=None, execute=False):
-        query = self.model.objects
-
-        #Select only the columns listed
-        # cols = self.list_display
-        # if cols:
-        #     query = query.only(*cols)
+        qs = self.get_queryset()
 
         #Calculate number of rows
-        count = query.count()
+        count = qs.count()
 
-        #Order query
+        #Order queryset
         if sort:
-            query = query.order_by('%s%s' % ('-' if sort_desc else '', sort))
+            qs = qs.order_by('%s%s' % ('-' if sort_desc else '', sort))
 
         # Pagination
         if page is not None:
-            query = query.all()[page * self.list_per_page:]
-        query = query[:self.list_per_page]
+            qs = qs.all()[page * self.list_per_page:]
+        qs = qs[:self.list_per_page]
 
         if execute:
-            query = list(query)
+            qs = list(qs)
 
-        return count, query
+        return count, qs

--- a/flask_superadmin/model/backends/sqlalchemy/view.py
+++ b/flask_superadmin/model/backends/sqlalchemy/view.py
@@ -55,14 +55,17 @@ class ModelAdmin(BaseModelAdmin):
 
     @property
     def query(self):
+        return self.get_queryset()  # TODO remove eventually (kept for backwards compatibility)
+
+    def get_queryset():
         return self.session.query(self.model)
 
     def get_objects(self, *pks):
         id = self.get_pk(self.model)
-        return self.query.filter(id.in_(pks))
+        return self.get_queryset().filter(id.in_(pks))
 
     def get_object(self, pk):
-        return self.query.get(pk)
+        return self.get_queryset().get(pk)
 
     def get_pk(self, instance):
         return getattr(instance, self._primary_key)
@@ -81,21 +84,22 @@ class ModelAdmin(BaseModelAdmin):
         return True
 
     def get_list(self, page=0, sort=None, sort_desc=None, execute=False):
-        query = self.session.query(self.model)
-        count = query.count()
-        #Order query
+        qs = self.get_queryset()
+        count = qs.count()
+        #Order queryset
         if sort:
             if sort_desc:
                 sort = desc(sort)
-            query = query.order_by(sort)
+            qs = qs.order_by(sort)
 
         # Pagination
         if page is not None:
-            query = query.offset(page * self.list_per_page)
+            qs = qs.offset(page * self.list_per_page)
 
-        query = query.limit(self.list_per_page)
+        qs = qs.limit(self.list_per_page)
 
         if execute:
-            query = query.all()
+            qs = qs.all()
 
-        return count, query
+        return count, qs
+

--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -123,7 +123,10 @@ class BaseModelAdmin(BaseView):
     def field_name(self, field):
         return prettify(field)
 
-    def get_list(sel):
+    def get_queryset(self):
+        raise NotImplemented()
+
+    def get_list(self):
         raise NotImplemented()
 
     def get_url_name(self, name):


### PR DESCRIPTION
Imagine having a simple MongoEngine document:

```
class User(Document):
    email = StringField(required=True)
    first_name = StringField(max_length=50)
    last_name = StringField(max_length=50)
    is_active = BooleanField(default=False)
```

Thanks to this pull request, if you'd like to show only active users in the admin, you'll be able to simple do:

```
class UserAdmin(model.ModelAdmin):
    list_display = ['email', 'first_name', 'last_name']

    def get_queryset():
        return self.model.objects.filter(is_active=True)
```

This approach works for all the backends.
