### PR TITLE
SQLAlchemy converter needs a view parameter

### DIFF
--- a/flask_superadmin/model/backends/sqlalchemy/view.py
+++ b/flask_superadmin/model/backends/sqlalchemy/view.py
@@ -48,7 +48,7 @@ class ModelAdmin(BaseModelAdmin):
         return model_form
 
     def get_converter(self):
-        return AdminModelConverter
+        return AdminModelConverter(self)
 
     @property
     def query(self):

--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -111,9 +111,11 @@ class BaseModelAdmin(BaseView):
 
         model_form = self.get_model_form()
         converter = self.get_converter()
+        if isinstance(converter, type):
+            converter = converter()
         form = model_form(self.model, base_class=BaseForm, only=only,
                           exclude=exclude, field_args=self.field_args,
-                          converter=converter())
+                          converter=converter)
 
         form.readonly_fields = self.readonly_fields
         return form


### PR DESCRIPTION
The sqla `AdminModelConverter` needs a `view` parameter in constructor.

I tried to not break compatibility, with `BaseModelAdmin` checking if `get_converter` response is a type or an instance.
