### PR TITLE
Fix read only fields lookup of endpoint field

### DIFF
--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -133,8 +133,9 @@ class BaseModelAdmin(BaseView):
     def get_readonly_fields(self, instance):
         ret_vals = {}
         for field in self.readonly_fields:
-            if hasattr(self, field):
-                val = getattr(self, field)(instance)
+            self_field = getattr(self, field, None)
+            if callable(self_field):
+                val = self_field(instance)
             else:
                 val = getattr(instance, field)
                 if callable(val):


### PR DESCRIPTION
I have an `endpoint` field and it breaks when I try to make it readonly because model base get the `self.endpoint` instead of `instance.endpoint`.
