### PR TITLE
[fix] Checking for session attr

### DIFF
--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -220,7 +220,7 @@ class BaseModelAdmin(BaseView):
                     return self.dispatch_save_redirect(instance)
                 except Exception, ex:
                     print traceback.format_exc()
-                    if self.session:
+                    if hasattr(self, 'session') and self.session:
                         self.session.rollback()
                     flash(gettext('Failed to add model. %(error)s',
                           error=str(ex)), 'error')


### PR DESCRIPTION
referencing to `self.session` raises an exception if session is not defined
