### PR TITLE
Update Travis link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ Flask-SuperAdmin
 ================
 
 
-.. image:: https://secure.travis-ci.org/SyrusAkbary/Flask-SuperAdmin.png?branch=master
-        :target: https://secure.travis-ci.org/SyrusAkbary/Flask-SuperAdmin
+.. image:: https://travis-ci.org/SyrusAkbary/Flask-SuperAdmin.png?branch=master
+        :target: https://travis-ci.org/SyrusAkbary/Flask-SuperAdmin
 
 Flask-Superadmin is the **best** admin interface framework for `Flask <http://flask.pocoo.org/>`_. As good as Django admin.
 


### PR DESCRIPTION
The current link redirect me to a blank screen in Travis.

```
$ curl -sI https://secure.travis-ci.org/SyrusAkbary/Flask-Super
Admin
HTTP/1.1 301 Moved Permanently
Content-Type: text/html
Location: https://travis-ci.org//SyrusAkbary/Flask-SuperAdmin
Connection: keep-alive
```

That double slash (`//SyrisAkbary`) is wrong. It is probably travis fault (I reported the bug there), but this change solve the problem.
