### PR TITLE
Create a ModelAdmin.not_editable_fields. 

### DIFF
--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -63,6 +63,7 @@ class BaseModelAdmin(BaseView):
     # admin, methods/fields on the model/document.
     fields = tuple()
     readonly_fields = tuple()
+    not_editable_fields = tuple()
     exclude = tuple()
 
     form = None
@@ -137,7 +138,8 @@ class BaseModelAdmin(BaseView):
 
     def get_readonly_fields(self, instance):
         ret_vals = {}
-        for field in self.readonly_fields:
+        fields = instance and self.not_editable_fields or self.readonly_fields
+        for field in fields:
             self_field = getattr(self, field, None)
             if callable(self_field):
                 val = self_field(instance)


### PR DESCRIPTION
If `not_editable_fields` is not empty, it is used instead of `readonly_fields` on edit model form. If it is not set, the edit model uses the `readonly_fields`.

I'm not confortable with these names, probably we need something better, but I'm sure the admin needs this feature. Django does not have it and I found some workarounds to make it work.

http://tech.fydd.in/2010/08/django-admin-making-fields-read-only.html
http://stackoverflow.com/questions/8976086/understanding-django-admin-readonly-fields

It is necessary the `fields` value to order fields. I want some fields readonly on edit but not on add.

If anyone has better names or a better approach, feel free to suggest, I'm not totally happy with this pull request, but it works for me.
