### PR TITLE
Fix formats bug in form.TimeField

### DIFF
--- a/flask_superadmin/form.py
+++ b/flask_superadmin/form.py
@@ -54,7 +54,7 @@ class TimeField(fields.Field):
         """
         super(TimeField, self).__init__(label, validators, **kwargs)
 
-        self.format = formats or ('%H:%M:%S', '%H:%M',
+        self.formats = formats or ('%H:%M:%S', '%H:%M',
                                   '%I:%M:%S%p', '%I:%M%p',
                                   '%I:%M:%S %p', '%I:%M %p')
 
@@ -62,7 +62,7 @@ class TimeField(fields.Field):
         if self.raw_data:
             return u' '.join(self.raw_data)
         else:
-            return self.data and self.data.strftime(self.format) or u''
+            return self.data and self.data.strftime(self.formats[0]) or u''
 
     def process_formdata(self, valuelist):
         if valuelist:


### PR DESCRIPTION
Thanks for a most useful package. I encountered an issue in admin forms that include time fields.
When submitting a form that includes a TimeField, an exception is thrown on form.py line 71:
`AttributeError: 'TimeField' object has no attribute 'formats'`

And when populating a value into a TimeField; form.py line 65:
`TypeError: strftime() argument 1 must be string or read-only buffer, not tuple`

My solution here works well enough for my needs but there's probably a better way to handle line 65 than just defaulting to the first item in the list of formats...
