### PR TITLE
fix fileadmin flask_wtf fields import

### DIFF
--- a/flask_superadmin/contrib/fileadmin.py
+++ b/flask_superadmin/contrib/fileadmin.py
@@ -14,7 +14,8 @@ from flask import flash, url_for, redirect, abort, request
 from flask_superadmin.base import BaseView, expose
 from flask_superadmin.babel import gettext, lazy_gettext
 from flask_superadmin import form
-from flask.ext import wtf
+from flask_wtf.file import FileField
+from wtforms import TextField, ValidationError
 
 
 class NameForm(form.BaseForm):
@@ -23,14 +24,14 @@ class NameForm(form.BaseForm):
 
         Validates if provided name is valid for *nix and Windows systems.
     """
-    name = wtf.TextField()
+    name = TextField()
 
     regexp = re.compile(r'^(?!^(PRN|AUX|CLOCK\$|NUL|CON|COM\d|LPT\d|\..*)'
                         r'(\..+)?$)[^\x00-\x1f\\?*:\";|/]+$')
 
     def validate_name(self, field):
         if not self.regexp.match(field.data):
-            raise wtf.ValidationError(gettext('Invalid directory name'))
+            raise ValidationError(gettext('Invalid directory name'))
 
 
 class UploadForm(form.BaseForm):
@@ -38,7 +39,7 @@ class UploadForm(form.BaseForm):
         File upload form. Works with FileAdmin instance to check if it
         is allowed to upload file with given extension.
     """
-    upload = wtf.FileField(lazy_gettext('File to upload'))
+    upload = FileField(lazy_gettext('File to upload'))
 
     def __init__(self, admin):
         self.admin = admin
@@ -47,12 +48,12 @@ class UploadForm(form.BaseForm):
 
     def validate_upload(self, field):
         if not self.upload.has_file():
-            raise wtf.ValidationError(gettext('File required.'))
+            raise ValidationError(gettext('File required.'))
 
         filename = self.upload.data.filename
 
         if not self.admin.is_file_allowed(filename):
-            raise wtf.ValidationError(gettext('Invalid file type.'))
+            raise ValidationError(gettext('Invalid file type.'))
 
 
 class FileAdmin(BaseView):


### PR DESCRIPTION
Using fileadmin raise AttributeError: 'module' object has no attribute 'TextField'.
Also this changes add correct import for flask_wtf FileField.
