### PR TITLE
Fix'd adding an item when readonly fields are set.

### DIFF
--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -138,6 +138,8 @@ class BaseModelAdmin(BaseView):
 
     def get_readonly_fields(self, instance):
         ret_vals = {}
+        if not instance:
+            return ret_vals
         for field in self.readonly_fields:
             self_field = getattr(self, field, None)
             if callable(self_field):


### PR DESCRIPTION
If you have readonly fields set you get an exception where instance isn't available.
By just returning early you just ignore the readonly fields when creating a new item.
