### PR TITLE
example/quickstart: Updated template to remove deprecated template messages

### DIFF
--- a/examples/quickstart/templates/index.html
+++ b/examples/quickstart/templates/index.html
@@ -1,4 +1,4 @@
-{% extends 'admin/master.html' %}
+{% extends 'admin/layout.html' %}
 {% block body %}
     Hello World from MyView!
 {% endblock %}


### PR DESCRIPTION
Removed deprecated template message from the quickstart example.

Without this code a new user will see the following message:

**DEPRECATED TEMPLATE: use admin/layout.html instead of admin/master.html**

With the fix, the example functions as expected
