### PR TITLE
update template base to remove deprecated template messages

### DIFF
--- a/examples/simple/templates/anotheradmin.html
+++ b/examples/simple/templates/anotheradmin.html
@@ -1,4 +1,4 @@
-{% extends 'admin/master.html' %}
+{% extends 'admin/layout.html' %}
 {% block body %}
     Hello World from AnotherMyAdmin!<br/>
     <a href="{{ url_for('.test') }}">Click me to go to test view</a>

--- a/examples/simple/templates/myadmin.html
+++ b/examples/simple/templates/myadmin.html
@@ -1,4 +1,4 @@
-{% extends 'admin/master.html' %}
+{% extends 'admin/layout.html' %}
 {% block body %}
     Hello World from MyAdmin!
 {% endblock %}

--- a/examples/simple/templates/test.html
+++ b/examples/simple/templates/test.html
@@ -1,4 +1,4 @@
-{% extends 'admin/master.html' %}
+{% extends 'admin/layout.html' %}
 {% block body %}
     This is TEST subitem from the AnotherAdminView!
 {% endblock %}


### PR DESCRIPTION
Removed deprecated template message from the simple example.

Without this code a new user will see the following message:

DEPRECATED TEMPLATE: use admin/layout.html instead of admin/master.html

With the fix, the example functions as expected
