### PR TITLE
Fix IntegrityError when deleting objects with foreign keys

### DIFF
--- a/flask_superadmin/model/backends/sqlalchemy/view.py
+++ b/flask_superadmin/model/backends/sqlalchemy/view.py
@@ -72,7 +72,7 @@ class ModelAdmin(BaseModelAdmin):
 
     def delete_models(self, *pks):
         objs = self.get_objects(*pks)
-        objs.delete(synchronize_session='fetch')
+        [self.session.delete(x) for x in objs]
         self.session.commit()
         return True
 


### PR DESCRIPTION
According to http://docs.sqlalchemy.org/en/rel_1_0/orm/query.html#sqlalchemy.orm.query.Query.delete,
query.delete() "does not offer in-Python cascading of relationships",
which essentially means that trying to delete such an object from Flask-SuperAdmin
results in an IntegrityError.

I suggest using the session.delete(object) method, as this also takes into account
any relationships defined in the SQLAlchemy models.

Please let me know what you think and last but not least, thank you :)