### PR TITLE
Fixed typographical error, changed adminstrative to administrative in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ project's models (MongoEngine, Django or SQLAlchemy).
 Introduction
 ------------
 
-This is library for building adminstrative interface on top of Flask framework.
+This is library for building administrative interface on top of Flask framework.
 
 Instead of providing simple scaffolding for SQLAlchemy, MongoEngine or Django models, Flask-SuperAdmin
-provides tools that can be used to build adminstrative interface of any complexity,
+provides tools that can be used to build administrative interface of any complexity,
 using consistent look and feel.
 
 


### PR DESCRIPTION
@syrusakbary, I've corrected a typographical error in the documentation of the [Flask-SuperAdmin](https://github.com/syrusakbary/Flask-SuperAdmin) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
